### PR TITLE
Remove unpackNils (fixes Lua ≥5.2 compat)

### DIFF
--- a/src/classes/utils/TML.ti
+++ b/src/classes/utils/TML.ti
@@ -1,18 +1,5 @@
 --[[
     @local
-    @desc A function that functions similarly to 'table.unpack', the difference being that this function doesn't stop at the first nil found.
-    @param <tbl - tbl> -- the table to unpack
-    @return [var - args...]
-]]
-local function unpackNils( tbl )
-    local str = {}
-    for i = 1, #tbl do str[ i ] = "tbl[" .. i .. "]" end
-
-    return loadstring( "local tbl = ...; return " .. table.concat( str, "," ) )( tbl )
-end
-
---[[
-    @local
     @desc Creates a table of arguments using the classes constructor configuration. This table is then unpacked (and the result returned)
     @param <Class Base - class>, <table - target>
     @return [var - args...]
@@ -42,7 +29,7 @@ local function formArguments( class, target )
         returnArguments[ #ordered + 1 ] = trailingTable
     end
 
-    return unpackNils( returnArguments )
+    return unpack( returnArguments, 1, next(trailingTable) and #ordered + 1 or #ordered )
 end
 
 --[[

--- a/src/classes/utils/TML.ti
+++ b/src/classes/utils/TML.ti
@@ -6,7 +6,7 @@
 ]]
 local function unpackNils( tbl )
     local str = {}
-    for i = 1, table.maxn( tbl ) do str[ i ] = "tbl[" .. i .. "]" end
+    for i = 1, #tbl do str[ i ] = "tbl[" .. i .. "]" end
 
     return loadstring( "local tbl = ...; return " .. table.concat( str, "," ) )( tbl )
 end


### PR DESCRIPTION
`table.maxn` doesn't exist in Lua ≥5.2

Also I haven't found that `unpack` stops at the first nil (e.g. `unpack{nil, 1} == nil, 1`) so `unpackNils` is probably unnecessary.