### PR TITLE
Use `visible` for rendering and context menus

### DIFF
--- a/src/classes/core/Application.ti
+++ b/src/classes/core/Application.ti
@@ -194,7 +194,7 @@ function Application:draw( force )
 
     for i = 1, #nodes do
         node = nodes[ i ]
-        if node.needsRedraw then
+        if node.needsRedraw and node.visible then
             node:draw( force )
 
             node.canvas:drawTo( canvas, node.X, node.Y )

--- a/src/classes/core/Node.ti
+++ b/src/classes/core/Node.ti
@@ -70,6 +70,9 @@ end
 function Node:setVisible( visible )
     self.visible = visible
     self.changed = true
+    if not visible then
+        self:queueAreaReset()
+    end
 end
 
 --[[

--- a/src/classes/nodes/Container.ti
+++ b/src/classes/nodes/Container.ti
@@ -52,7 +52,7 @@ function Container:draw( force, offsetX, offsetY )
         for i = 1, #nodes do
             node = nodes[ i ]
 
-            if node.needsRedraw then
+            if node.needsRedraw and node.visible then
                 node:draw( force )
 
                 node.canvas:drawTo( canvas, node.X + offsetX, node.Y + offsetY )

--- a/src/classes/nodes/ContextMenu.ti
+++ b/src/classes/nodes/ContextMenu.ti
@@ -6,7 +6,6 @@ class ContextMenu extends Container {
     static = {
         allowedTypes = { "Button", "Label" }
     };
-    openFrames = {};
 }
 
 --[[
@@ -37,7 +36,7 @@ function ContextMenu:setParent( parent )
         frame.frameID = 1
 
         self:populate( frame, self.structure )
-        self.openFrames[ frame ] = true
+        frame.visible = true
     end
 end
 
@@ -72,20 +71,22 @@ function ContextMenu:populate( frame, structure )
                         table.insert( menu.subframes, subframe )
                     end
 
+                    subframe.visible = false
+
                     local id = #self.nodes
                     subframe.frameID = id
                     menu:addNode( Button( part[ 2 ], 1, Y ):on( "trigger", function()
                         local subframes = menu.subframes
                         for i = 1, #subframes do
-                            if subframes[ i ] ~= subframe and self.openFrames[ subframes[ i ] ] then
+                            if subframes[ i ] ~= subframe and subframes[ i ].visible then
                                 self:closeFrame( subframes[ i ].frameID )
                             end
                         end
 
-                        if self.openFrames[ subframe ] then
+                        if subframe.visible then
                             self:closeFrame( id )
                         else
-                            self.openFrames[ subframe ] = true
+                            subframe.visible = true
                         end
                     end ) )
 
@@ -150,7 +151,7 @@ end
 function ContextMenu:shipEvent( event )
     local nodes = self.nodes
     for i = #nodes, 1, -1 do
-        if self.openFrames[ nodes[ i ] ] then
+        if nodes[ i ].visible then
             nodes[ i ]:handle( event )
         end
     end
@@ -165,7 +166,7 @@ end
     Note: Uses vararg to avoid potential extensibility issues. We only need to know about the node.
 ]]
 function ContextMenu:isNodeInBounds( node, ... )
-    if not self.openFrames[ node ] then return false end
+    if not node.visible then return false end
 
     return self.super:isNodeInBounds( node, ... )
 end
@@ -184,7 +185,7 @@ function ContextMenu:onMouseClick( event, handled, within )
         local node = nodes[ i ]
         local nodeX, nodeY = node.X, node.Y
 
-        if self.openFrames[ node ] and eX >= nodeX and eX <= nodeX + node.width - 1 and eY >= nodeY and eY <= nodeY + node.height - 1 then
+        if node.visible and eX >= nodeX and eX <= nodeX + node.width - 1 and eY >= nodeY and eY <= nodeY + node.height - 1 then
             return true
         end
     end
@@ -198,16 +199,16 @@ end
     @param <number - frameID>
 ]]
 function ContextMenu:closeFrame( frameID )
-    local framesToClose, open, i = { self.nodes[ frameID ] }, self.openFrames, 1
+    local framesToClose, i = { self.nodes[ frameID ] }, 1
     while i <= #framesToClose do
         local subframes = framesToClose[ i ].subframes or {}
         for f = 1, #subframes do
-            if open[ subframes[ f ] ] then
+            if subframes[ f ].visible then
                 framesToClose[ #framesToClose + 1 ] = subframes[ f ]
             end
         end
 
-        open[ framesToClose[ i ] ] = nil
+        framesToClose[ i ].visible = false
         i = i + 1
     end
 

--- a/src/mixins/MNodeContainer.ti
+++ b/src/mixins/MNodeContainer.ti
@@ -167,4 +167,10 @@ function MNodeContainer:redrawArea( x, y, width, height, xOffset, yOffset )
             node.needsRedraw = true
         end
     end
+
+    -- TODO: xOffset and yOffset don't work here, that whole thing probably need to change
+    local parent = self.parent
+    if parent then
+        parent:redrawArea(self.X + x, self.Y + y, width, height)
+    end
 end


### PR DESCRIPTION
This should fix #15 and #17 

context menus are still broken though:
- it's possible to have multiple open if you right-click inside an existing context menu
- the sub menu button stays active (on screen, but `active` seems to be false the next time it's rendered)
- context menus are never deleted, just all of their children are set to `visible = false`